### PR TITLE
feat: configure the GPUs for the service as a list instead of count

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Documentation for the endpoints is provided by the service and can be found at t
 
 ## Configuration
 
-SAM Service can be configured by modifying the `config.py` file. This file includes settings for available GPUS and log levels.
+SAM Service can be configured by modifying the `config.json` file. This file includes settings for available GPUS and log levels.
 
 ## Contributing
 

--- a/sam_service/config.json
+++ b/sam_service/config.json
@@ -1,4 +1,4 @@
 {
     "SECRET_KEY": "cdas69786cdsa^%#FDS^%$gfd65#$dfs#@$#@?><i:OI)(*-",
-    "GPU_COUNT": 8
+    "GPUS": [0, 1, 2, 3, 4, 5, 6, 7]
 }

--- a/sam_service/sam_fast_api.py
+++ b/sam_service/sam_fast_api.py
@@ -44,9 +44,10 @@ if torch.cuda.is_available():
     # if gpus are specified in the config file, then use a gpu based
     # on the process id, to distribute the load across the gpus by
     # flask process
-    gpu_count = config.get('GPU_COUNT', 1)
+    gpus = config.get('GPUS', [0])
+    gpu_count = len(gpus)
     if gpu_count > 1:
-        device = f'cuda:{str(os.getpid() % gpu_count)}'
+        device = f'cuda:{str(gpus[os.getpid() % gpu_count])}'
 
 
 sam = sam_model_registry[model_type](checkpoint=checkpoint)


### PR DESCRIPTION
      (this is useful on desktops to exclude the display GPU or to only
      use the GPUs that are appropriate for the service)